### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "londonlink",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "English Learning Platform with Brazilian Portuguese Focus",
   "author": "Mages.dev",
   "license": "UNLICENSED",

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -295,7 +295,7 @@ export default function Header({
             windowWidth < 817 ? "block" : "hidden"
           } ${
             isMobileMenuOpen
-              ? "max-h-96 opacity-100 mt-6"
+              ? "max-h-screen opacity-100 mt-6"
               : "max-h-0 opacity-0 overflow-hidden"
           }`}
         >

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -7,7 +7,7 @@
  * Current application version
  * Update this when releasing new versions
  */
-export const APP_VERSION = "1.0.0";
+export const APP_VERSION = "1.0.1";
 
 /**
  * Application name


### PR DESCRIPTION
bump version to 1.0.1

- Fix bug fixes and minor improvements
- Update package.json and version.ts to v1.0.1

fix(header): corrige menu mobile cortando item "Contato"

- Altera max-h-96 para max-h-screen no menu mobile
- Garante que todos os 7 itens de navegação sejam visíveis
- Resolve problema de overflow que cortava o último item do menu
- Mantém animação suave de abertura/fechamento